### PR TITLE
Add support for using ingress

### DIFF
--- a/stable/helm-exporter/Chart.yaml
+++ b/stable/helm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: Exports helm release stats to prometheus
 name: helm-exporter
-version: 0.2.3
+version: 0.3.0
 home: https://github.com/sstarcher/helm-exporter
 sources:
 - https://github.com/sstarcher/helm-exporter

--- a/stable/helm-exporter/README.md
+++ b/stable/helm-exporter/README.md
@@ -52,7 +52,10 @@ Parameter | Description | Default
 `serviceMonitor.interval` | Interval at which metrics should be scraped | ``
 `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | ``
 `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}`
-
+`ingress.enabled` | Set to true if using an ingress | `false`
+`ingress.annotations` | Ingress annotations | `{}`
+`ingress.path` | Ingress path | `/`
+`ingress.host` | Ingress hostname e.g example.com | ``
 ```console
 $ helm install stable/helm-exporter --name my-release
 ```

--- a/stable/helm-exporter/templates/ingress.yaml
+++ b/stable/helm-exporter/templates/ingress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "helm-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "helm-exporter.name" . }}
+    helm.sh/chart: {{ include "helm-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ include "helm-exporter.name" . }}
+              servicePort: 9571
+{{- end }}

--- a/stable/helm-exporter/templates/service.yaml
+++ b/stable/helm-exporter/templates/service.yaml
@@ -13,7 +13,9 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- if not .Values.ingress.enabled }}
   clusterIP: None
+  {{- end }}
   ports:
     - port: 9571
       targetPort: http

--- a/stable/helm-exporter/values.yaml
+++ b/stable/helm-exporter/values.yaml
@@ -36,3 +36,13 @@ serviceMonitor:
   interval:
   namespace:
   additionalLabels: {}
+
+ingress:
+  # Specifies whether an Ingress should be created
+  enabled: false
+
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  path: /
+  # Name of host e.g example.com
+  host:


### PR DESCRIPTION
Signed-off-by: Christopher Farrenden <chris.farrenden@domain.com.au>

#### What this PR does / why we need it:
Add ingress support for helm-exporter so that it can be accessed by external services

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[stable/chart]`)
